### PR TITLE
Remove preview args from JDK tests

### DIFF
--- a/test/jdk/java/io/Serializable/records/AbsentStreamValuesTest.java
+++ b/test/jdk/java/io/Serializable/records/AbsentStreamValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Checks that the appropriate default value is given to the canonical ctr
- * @compile --enable-preview -source ${jdk.version} AbsentStreamValuesTest.java
- * @run testng/othervm --enable-preview AbsentStreamValuesTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview AbsentStreamValuesTest
+ * @run testng/othervm AbsentStreamValuesTest
+ * @run testng/othervm/java.security.policy=empty_security.policy AbsentStreamValuesTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/BadCanonicalCtrTest.java
+++ b/test/jdk/java/io/Serializable/records/BadCanonicalCtrTest.java
@@ -27,8 +27,7 @@
  *          cannot be found during deserialization.
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @compile --enable-preview -source ${jdk.version} BadCanonicalCtrTest.java
- * @run testng/othervm --enable-preview BadCanonicalCtrTest
+ * @run testng/othervm BadCanonicalCtrTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -59,7 +58,6 @@ import static org.testng.Assert.expectThrows;
  * constructor cannot be found during deserialization.
  */
 public class BadCanonicalCtrTest {
-    private static final String VERSION = Integer.toString(Runtime.version().feature());
 
     // ClassLoader for creating instances of the records to test with.
     ClassLoader goodRecordClassLoader;
@@ -79,8 +77,7 @@ public class BadCanonicalCtrTest {
     public void setup() {
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("R1",
-                    "public record R1 () implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record R1 () implements java.io.Serializable { }");
             goodRecordClassLoader = new ByteCodeLoader("R1", byteCode, BadCanonicalCtrTest.class.getClassLoader());
             byte[] bc1 = removeConstructor(byteCode);
             missingCtrClassLoader = new ByteCodeLoader("R1", bc1, BadCanonicalCtrTest.class.getClassLoader());
@@ -89,8 +86,7 @@ public class BadCanonicalCtrTest {
         }
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("R2",
-                    "public record R2 (int x, int y) implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record R2 (int x, int y) implements java.io.Serializable { }");
             goodRecordClassLoader = new ByteCodeLoader("R2", byteCode, goodRecordClassLoader);
             byte[] bc1 = removeConstructor(byteCode);
             missingCtrClassLoader = new ByteCodeLoader("R2", bc1, missingCtrClassLoader);
@@ -101,8 +97,7 @@ public class BadCanonicalCtrTest {
             byte[] byteCode = InMemoryJavaCompiler.compile("R3",
                     "public record R3 (long l) implements java.io.Externalizable {" +
                     "    public void writeExternal(java.io.ObjectOutput out) { }" +
-                    "    public void readExternal(java.io.ObjectInput in)    { } }",
-                    "--enable-preview", "-source", VERSION);
+                    "    public void readExternal(java.io.ObjectInput in)    { } }");
             goodRecordClassLoader = new ByteCodeLoader("R3", byteCode, goodRecordClassLoader);
             byte[] bc1 = removeConstructor(byteCode);
             missingCtrClassLoader = new ByteCodeLoader("R3", bc1, missingCtrClassLoader);

--- a/test/jdk/java/io/Serializable/records/BasicRecordSer.java
+++ b/test/jdk/java/io/Serializable/records/BasicRecordSer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Basic test that serializes and deserializes a number of records
- * @compile --enable-preview -source ${jdk.version} BasicRecordSer.java
- * @run testng/othervm --enable-preview BasicRecordSer
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview BasicRecordSer
+ * @run testng/othervm BasicRecordSer
+ * @run testng/othervm/java.security.policy=empty_security.policy BasicRecordSer
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/ConstructorAccessTest.java
+++ b/test/jdk/java/io/Serializable/records/ConstructorAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,8 @@
  * @test
  * @summary Ensures that the serialization implementation can *always* access
  *          the record constructor
- * @compile --enable-preview -source ${jdk.version} ConstructorAccessTest.java
- * @run testng/othervm --enable-preview ConstructorAccessTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview ConstructorAccessTest
+ * @run testng/othervm ConstructorAccessTest
+ * @run testng/othervm/java.security.policy=empty_security.policy ConstructorAccessTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/ConstructorPermissionTest.java
+++ b/test/jdk/java/io/Serializable/records/ConstructorPermissionTest.java
@@ -25,8 +25,7 @@
  * @test
  * @summary Verifies that privileged operations performed in the record
  *          constructor throw, when run without the required permissions
- * @compile --enable-preview -source ${jdk.version} ConstructorPermissionTest.java
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview ConstructorPermissionTest
+ * @run testng/othervm/java.security.policy=empty_security.policy ConstructorPermissionTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/CycleTest.java
+++ b/test/jdk/java/io/Serializable/records/CycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Ensures basic behavior of cycles from record components
- * @compile --enable-preview -source ${jdk.version} CycleTest.java
- * @run testng/othervm --enable-preview CycleTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview CycleTest
+ * @run testng/othervm CycleTest
+ * @run testng/othervm/java.security.policy=empty_security.policy CycleTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/DifferentStreamFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/DifferentStreamFieldsTest.java
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Checks that the appropriate value is given to the canonical ctr
- * @compile --enable-preview -source ${jdk.version} DifferentStreamFieldsTest.java
- * @run testng/othervm --enable-preview DifferentStreamFieldsTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview DifferentStreamFieldsTest
+ * @run testng/othervm DifferentStreamFieldsTest
+ * @run testng/othervm/java.security.policy=empty_security.policy DifferentStreamFieldsTest
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
+++ b/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
@@ -26,8 +26,7 @@
  * @summary Basic tests for prohibited magic serialization methods
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @compile --enable-preview -source ${jdk.version} ProhibitedMethods.java
- * @run testng/othervm --enable-preview ProhibitedMethods
+ * @run testng/othervm ProhibitedMethods
  */
 
 import java.io.ByteArrayInputStream;
@@ -69,7 +68,6 @@ import static org.testng.Assert.fail;
  * record objects.
  */
 public class ProhibitedMethods {
-    private static final String VERSION = Integer.toString(Runtime.version().feature());
 
     public interface ThrowingExternalizable extends Externalizable {
         default void writeExternal(ObjectOutput out) {
@@ -106,8 +104,7 @@ public class ProhibitedMethods {
     public void setup() {
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("Foo",
-                    "public record Foo () implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record Foo () implements java.io.Serializable { }");
             byteCode = addWriteObject(byteCode);
             byteCode = addReadObject(byteCode);
             byteCode = addReadObjectNoData(byteCode);
@@ -115,8 +112,7 @@ public class ProhibitedMethods {
         }
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("Bar",
-                    "public record Bar (int x, int y) implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record Bar (int x, int y) implements java.io.Serializable { }");
             byteCode = addWriteObject(byteCode);
             byteCode = addReadObject(byteCode);
             byteCode = addReadObjectNoData(byteCode);
@@ -125,8 +121,7 @@ public class ProhibitedMethods {
         {
             byte[] byteCode = InMemoryJavaCompiler.compile("Baz",
                     "import java.io.Serializable;" +
-                    "public record Baz<U extends Serializable,V extends Serializable>(U u, V v) implements Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record Baz<U extends Serializable,V extends Serializable>(U u, V v) implements Serializable { }");
             byteCode = addWriteObject(byteCode);
             byteCode = addReadObject(byteCode);
             byteCode = addReadObjectNoData(byteCode);

--- a/test/jdk/java/io/Serializable/records/ReadResolveTest.java
+++ b/test/jdk/java/io/Serializable/records/ReadResolveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Basic tests for readResolve
- * @compile --enable-preview -source ${jdk.version} ReadResolveTest.java
- * @run testng/othervm --enable-preview ReadResolveTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview ReadResolveTest
+ * @run testng/othervm ReadResolveTest
+ * @run testng/othervm/java.security.policy=empty_security.policy ReadResolveTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/RecordClassTest.java
+++ b/test/jdk/java/io/Serializable/records/RecordClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Basic tests for serializing and deserializing record classes
- * @compile --enable-preview -source ${jdk.version} RecordClassTest.java
- * @run testng/othervm --enable-preview RecordClassTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview RecordClassTest
+ * @run testng/othervm RecordClassTest
+ * @run testng/othervm/java.security.policy=empty_security.policy RecordClassTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/SerialPersistentFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/SerialPersistentFieldsTest.java
@@ -26,8 +26,7 @@
  * @summary Basic tests for prohibited magic serialPersistentFields
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @compile --enable-preview -source ${jdk.version} SerialPersistentFieldsTest.java
- * @run testng/othervm --enable-preview SerialPersistentFieldsTest
+ * @run testng/othervm SerialPersistentFieldsTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -62,7 +61,6 @@ import static org.testng.Assert.assertTrue;
  * Checks that the serialPersistentFields declaration is effectively ignored.
  */
 public class SerialPersistentFieldsTest {
-    private static final String VERSION = Integer.toString(Runtime.version().feature());
 
     ClassLoader serializableRecordLoader;
 
@@ -83,8 +81,7 @@ public class SerialPersistentFieldsTest {
     public void setup() {
         {  // R1
             byte[] byteCode = InMemoryJavaCompiler.compile("R1",
-                    "public record R1 () implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record R1 () implements java.io.Serializable { }");
             ObjectStreamField[] serialPersistentFields = {
                     new ObjectStreamField("s", String.class),
                     new ObjectStreamField("i", int.class),
@@ -96,8 +93,7 @@ public class SerialPersistentFieldsTest {
         }
         {  // R2
             byte[] byteCode = InMemoryJavaCompiler.compile("R2",
-                    "public record R2 (int x) implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record R2 (int x) implements java.io.Serializable { }");
             ObjectStreamField[] serialPersistentFields = {
                     new ObjectStreamField("s", String.class)
             };
@@ -106,8 +102,7 @@ public class SerialPersistentFieldsTest {
         }
         {  // R3
             byte[] byteCode = InMemoryJavaCompiler.compile("R3",
-                    "public record R3 (int x, int y) implements java.io.Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record R3 (int x, int y) implements java.io.Serializable { }");
             ObjectStreamField[] serialPersistentFields = new ObjectStreamField[0];
             byteCode = addSerialPersistentFields(byteCode, serialPersistentFields);
             serializableRecordLoader = new ByteCodeLoader("R3", byteCode, serializableRecordLoader);
@@ -115,8 +110,7 @@ public class SerialPersistentFieldsTest {
         {  // R4
             byte[] byteCode = InMemoryJavaCompiler.compile("R4",
                     "import java.io.Serializable;" +
-                    "public record R4<U extends Serializable,V extends Serializable>(U u, V v) implements Serializable { }",
-                    "--enable-preview", "-source", VERSION);
+                    "public record R4<U extends Serializable,V extends Serializable>(U u, V v) implements Serializable { }");
             ObjectStreamField[] serialPersistentFields = {
                     new ObjectStreamField("v", String.class)
             };
@@ -132,8 +126,7 @@ public class SerialPersistentFieldsTest {
                     "    }\n" +
                     "    @Override public void readExternal(ObjectInput in) {\n" +
                     "        throw new AssertionError(\"should not reach here\");\n" +
-                    "    }  }",
-                    "--enable-preview", "-source", VERSION);
+                    "    }  }");
             ObjectStreamField[] serialPersistentFields = {
                     new ObjectStreamField("v", String.class)
             };

--- a/test/jdk/java/io/Serializable/records/SerialVersionUIDTest.java
+++ b/test/jdk/java/io/Serializable/records/SerialVersionUIDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Basic tests for SUID in the serial stream
- * @compile --enable-preview -source ${jdk.version} SerialVersionUIDTest.java
- * @run testng/othervm --enable-preview SerialVersionUIDTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview SerialVersionUIDTest
+ * @run testng/othervm SerialVersionUIDTest
+ * @run testng/othervm/java.security.policy=empty_security.policy SerialVersionUIDTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/StreamRefTest.java
+++ b/test/jdk/java/io/Serializable/records/StreamRefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,7 @@
 /*
  * @test
  * @summary Tests for stream references
- * @compile --enable-preview -source ${jdk.version} StreamRefTest.java
- * @run testng/othervm --enable-preview StreamRefTest
+ * @run testng/othervm StreamRefTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/ThrowingConstructorTest.java
+++ b/test/jdk/java/io/Serializable/records/ThrowingConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Tests constructor invocation exceptions are handled appropriately
- * @compile --enable-preview -source ${jdk.version} ThrowingConstructorTest.java
- * @run testng/othervm --enable-preview ThrowingConstructorTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview ThrowingConstructorTest
+ * @run testng/othervm ThrowingConstructorTest
+ * @run testng/othervm/java.security.policy=empty_security.policy ThrowingConstructorTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/UnsharedTest.java
+++ b/test/jdk/java/io/Serializable/records/UnsharedTest.java
@@ -25,8 +25,7 @@
  * @test
  * @bug 8238763
  * @summary ObjectInputStream readUnshared method handling of Records
- * @compile --enable-preview -source ${jdk.version} UnsharedTest.java
- * @run testng/othervm --enable-preview UnsharedTest
+ * @run testng/othervm UnsharedTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/WriteReplaceTest.java
+++ b/test/jdk/java/io/Serializable/records/WriteReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Basic tests for writeReplace
- * @compile --enable-preview -source ${jdk.version} WriteReplaceTest.java
- * @run testng/othervm --enable-preview WriteReplaceTest
- * @run testng/othervm/java.security.policy=empty_security.policy --enable-preview WriteReplaceTest
+ * @run testng/othervm WriteReplaceTest
+ * @run testng/othervm/java.security.policy=empty_security.policy WriteReplaceTest
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/io/Serializable/records/migration/AbstractTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/AbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,6 @@ import static org.testng.Assert.*;
  */
 public class AbstractTest {
 
-    private static final String VERSION = Integer.toString(Runtime.version().feature());
-
     static final String TEST_SRC = System.getProperty("test.src", ".");
     static final String TEST_CLASSES = System.getProperty("test.classes", ".");
     static final Path TEST_CLASSES_DIR = Path.of(TEST_CLASSES);
@@ -59,11 +57,9 @@ public class AbstractTest {
     @BeforeTest
     public void setup() throws IOException {
         assertTrue(CompilerUtils.compile(PLAIN_SRC_DIR, PLAIN_DEST_DIR,
-                   "--enable-preview", "-source", VERSION,
                    "--class-path", TEST_CLASSES_DIR.toString()));
 
         assertTrue(CompilerUtils.compile(RECORD_SRC_DIR, RECORD_DEST_DIR,
-                   "--enable-preview", "-source", VERSION,
                    "--class-path", TEST_CLASSES_DIR.toString()));
     }
 

--- a/test/jdk/java/io/Serializable/records/migration/AssignableFromTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/AssignableFromTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
  * @summary Test for subtype stream field value assign-ability
  * @library /test/lib
  * @modules jdk.compiler
- * @compile --enable-preview -source ${jdk.version} AssignableFrom.java Point.java
+ * @compile AssignableFrom.java Point.java
  *          DefaultValues.java SuperStreamFields.java AssignableFromTest.java
- * @run testng/othervm --enable-preview AssignableFromTest
+ * @run testng/othervm AssignableFromTest
  */
 
 import java.math.BigDecimal;

--- a/test/jdk/java/io/Serializable/records/migration/DefaultValuesTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/DefaultValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
  * @summary Checks that the appropriate default value is given to the canonical ctr
  * @library /test/lib
  * @modules jdk.compiler
- * @compile --enable-preview -source ${jdk.version} AssignableFrom.java Point.java
+ * @compile AssignableFrom.java Point.java
  *          DefaultValues.java SuperStreamFields.java DefaultValuesTest.java
- * @run testng/othervm --enable-preview DefaultValuesTest
+ * @run testng/othervm DefaultValuesTest
  */
 
 import java.io.ByteArrayOutputStream;

--- a/test/jdk/java/io/Serializable/records/migration/SuperStreamFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/migration/SuperStreamFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
  * @summary superclass fields in the stream should be discarded
  * @library /test/lib
  * @modules jdk.compiler
- * @compile --enable-preview -source ${jdk.version} AssignableFrom.java Point.java
+ * @compile AssignableFrom.java Point.java
  *          DefaultValues.java SuperStreamFields.java SuperStreamFieldsTest.java
- * @run testng/othervm --enable-preview SuperStreamFieldsTest
+ * @run testng/othervm SuperStreamFieldsTest
  */
 
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/runtime/ObjectMethodsTest.java
+++ b/test/jdk/java/lang/runtime/ObjectMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,8 @@
 /*
  * @test
  * @summary Basic tests for ObjectMethods
- * @compile --enable-preview -source ${jdk.version} ObjectMethodsTest.java
- * @run testng/othervm --enable-preview ObjectMethodsTest
- * @run testng/othervm/java.security.policy=empty.policy --enable-preview ObjectMethodsTest
+ * @run testng/othervm ObjectMethodsTest
+ * @run testng/othervm/java.security.policy=empty.policy ObjectMethodsTest
  */
 
 import java.lang.invoke.CallSite;


### PR DESCRIPTION
Remove preview args from record serialization tests and ObjectMethodsTest