### PR TITLE
Attempting to improve the fix.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -242,6 +242,14 @@ public class Annotate {
         s.resetAnnotations(); // mark Annotations as incomplete for now
 
         normal(() -> {
+            // Packages are unusual, in that they are the only type of declaration that can legally appear
+            // more than once in a compilation, and in all cases refer to the same underlying symbol.
+            // This means they are the only kind of declaration that syntactically may have multiple sets
+            // of annotations, each on a different package declaration, even though that is ultimately
+            // forbidden by JLS 8 section 7.4.
+            // The corollary here is that all of the annotations on a package symbol may have already
+            // been handled, meaning that the set of annotations pending completion is now empty.
+            Assert.check(s.kind == PCK || s.annotationsPendingCompletion());
             JavaFileObject prev = log.useSource(localEnv.toplevel.sourcefile);
             DiagnosticPosition prevLintPos =
                     deferPos != null


### PR DESCRIPTION
This is a proposal for a change for https://github.com/openjdk/jdk/pull/16443.
I believe the original problem is roughly this: the `pkg.T` class is available twice, once on the classpath, once in the source files provided on the command line. Normally, the latter would prevail. But, when the duplicate error is produced, it will do `kindName` on the original symbol, causing a `typeEnter` complete inside the `Enter.classEnter` phase. As javac haven't see the source for `pkg.T` yet in `Enter`, it will complete `pkg.T` from the classfile, and the error will be reported. But then, the `Enter.complete` will continue, and it will eventually find the class in the source, and complete it as well. I am surprised it does not fail on some kind of duplicate error as well, but it eventually fails with the annotation error.

The proposal here is to avoid the `typeEnter` complete while `Enter.classEnter` is running, by deferring setting of the completer. It should prevent all kinds of errors caused by the duplicate load. I think this should be more reliable, albeit at the cost of introducing yet-another todo-like queue.